### PR TITLE
sf-web-app #43

### DIFF
--- a/src/app/performance/[fund]/[holding]/page.tsx
+++ b/src/app/performance/[fund]/[holding]/page.tsx
@@ -125,7 +125,7 @@ export default function Page() {
               label={params.holding}
             />
           </Card>
-          <div className="flex flex-col gap-4 w-full">
+          <div className="flex flex-col gap-4 w-2/3">
             <Card className="flex flex-col w-full">
               <div className="text-center py-4 border-b border-solid">
                 Dividends


### PR DESCRIPTION
I fixed the returns chart width on the performance/fund/holding page. I made it as big as possible without the text wrapping in the "Dividends" and Last 5 Trades tables. 