### PR TITLE
added tracking error and holding metrics

### DIFF
--- a/src/app/forecast/[fund]/page.tsx
+++ b/src/app/forecast/[fund]/page.tsx
@@ -44,7 +44,7 @@ export default function FactorExposures() {
     factorParam,
     holdingParam,
   );
-  const { riskForecast } = useRiskForecast(fund);
+  const { riskForecast } = useRiskForecast(fund, holdingParam || undefined);
 
   const fundKeys = [
     "all_funds",

--- a/src/components/forecast/RiskForecastTable.tsx
+++ b/src/components/forecast/RiskForecastTable.tsx
@@ -36,6 +36,23 @@ function MetricCard({
   );
 }
 
+function getTitle(forecast?: RiskForecast, fundName?: string) {
+  if (forecast?.ticker) return `${forecast.ticker} Risk Forecast`;
+  if (fundName) return `${fundName} Risk Forecast`;
+  return "Risk Forecast";
+}
+
+function getPortfolioWeightOrTrackingError(
+  forecast?: RiskForecast,
+): string | undefined {
+  if (!forecast) return undefined;
+  if (forecast.ticker) {
+    if (forecast.fund_weight == null) return "-";
+    return `${(forecast.fund_weight * 100).toFixed(2)}%`;
+  }
+  return `${(forecast.tracking_error * 100).toFixed(2)}%`;
+}
+
 export function RiskForecastTable({
   forecast,
   fundName,
@@ -46,11 +63,7 @@ export function RiskForecastTable({
     <Card className="bg-gray border-none shadow-none text-card-foreground">
       <CardHeader className="pb-0">
         <CardTitle className="text-lg text-left border-b pb-2">
-          {forecast?.ticker
-            ? `${forecast.ticker} Risk Forecast`
-            : fundName
-              ? `${fundName} Risk Forecast`
-              : "Risk Forecast"}
+          {getTitle(forecast, fundName)}
         </CardTitle>
       </CardHeader>
 
@@ -73,13 +86,7 @@ export function RiskForecastTable({
           <MetricCard
             title={forecast?.ticker ? "Portfolio Weight" : "Tracking Error"}
             loading={loading}
-            value={
-              !forecast
-                ? undefined
-                : forecast.ticker
-                  ? `${(forecast.fund_weight! * 100).toFixed(2)}%`
-                  : `${(forecast.tracking_error * 100).toFixed(2)}%`
-            }
+            value={getPortfolioWeightOrTrackingError(forecast)}
           />
         </div>
       </CardContent>

--- a/src/components/forecast/RiskForecastTable.tsx
+++ b/src/components/forecast/RiskForecastTable.tsx
@@ -46,7 +46,11 @@ export function RiskForecastTable({
     <Card className="bg-gray border-none shadow-none text-card-foreground">
       <CardHeader className="pb-0">
         <CardTitle className="text-lg text-left border-b pb-2">
-          {fundName ? `${fundName} Risk Forecast` : "Risk Forecast"}
+          {forecast?.ticker
+            ? `${forecast.ticker} Risk Forecast`
+            : fundName
+              ? `${fundName} Risk Forecast`
+              : "Risk Forecast"}
         </CardTitle>
       </CardHeader>
 
@@ -58,19 +62,23 @@ export function RiskForecastTable({
             value={forecast ? forecast.beta.toFixed(2) : undefined}
           />
           <MetricCard
-            title="Variance"
-            loading={loading}
-            value={
-              forecast ? `${(forecast.variance * 100).toFixed(2)}%` : undefined
-            }
-          />
-          <MetricCard
             title="Volatility"
             loading={loading}
             value={
               forecast
                 ? `${(forecast.volatility * 100).toFixed(2)}%`
                 : undefined
+            }
+          />
+          <MetricCard
+            title={forecast?.ticker ? "Portfolio Weight" : "Tracking Error"}
+            loading={loading}
+            value={
+              !forecast
+                ? undefined
+                : forecast.ticker
+                  ? `${(forecast.fund_weight! * 100).toFixed(2)}%`
+                  : `${(forecast.tracking_error * 100).toFixed(2)}%`
             }
           />
         </div>

--- a/src/components/forecast/hooks/useRiskForecast.ts
+++ b/src/components/forecast/hooks/useRiskForecast.ts
@@ -4,11 +4,12 @@ import { useEffect, useState } from "react";
 import {
   getFundRiskForecast,
   getAllFundsRiskForecast,
+  getFundHoldingRiskForecast,
 } from "@/lib/api/riskForecast";
 
 import { RiskForecast } from "@/lib/types";
 
-export function useRiskForecast(fund?: string) {
+export function useRiskForecast(fund?: string, ticker?: string) {
   const [riskForecast, setRiskForecast] = useState<RiskForecast | undefined>(
     undefined,
   );
@@ -17,16 +18,20 @@ export function useRiskForecast(fund?: string) {
 
   useEffect(() => {
     if (!fund) return;
+    const currentFund = fund;
     let mounted = true;
     async function fetchRiskForecast() {
       setLoading(true);
       setError(undefined);
       try {
-        const f = fund as string;
-        const data =
-          f === "all_funds"
-            ? await getAllFundsRiskForecast()
-            : await getFundRiskForecast(f);
+        let data: RiskForecast;
+        if (ticker) {
+          data = await getFundHoldingRiskForecast(currentFund, ticker);
+        } else if (currentFund === "all_funds") {
+          data = await getAllFundsRiskForecast();
+        } else {
+          data = await getFundRiskForecast(currentFund);
+        }
         if (!mounted) return;
         setRiskForecast(data);
       } catch (err) {
@@ -42,7 +47,7 @@ export function useRiskForecast(fund?: string) {
     }
     fetchRiskForecast();
     return () => void (mounted = false);
-  }, [fund]);
+  }, [fund, ticker]);
 
   return { riskForecast, loading, error };
 }

--- a/src/lib/api/riskForecast.ts
+++ b/src/lib/api/riskForecast.ts
@@ -57,3 +57,31 @@ export async function getFundRiskForecast(fund: string): Promise<RiskForecast> {
     throw new Error("Failed to fetch fund risk forecast.");
   }
 }
+
+// GET /risk_forecast/{fund}/holdings/{ticker}
+export async function getFundHoldingRiskForecast(
+  fund: string,
+  ticker: string,
+): Promise<RiskForecast> {
+  try {
+    const headers = await getAuthHeader();
+
+    const response = await fetch(
+      API_BASE_URL + `risk_forecast/${fund}/holdings/${ticker}`,
+      {
+        method: "GET",
+        headers,
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const result: RiskForecast = await response.json();
+    return result;
+  } catch (error) {
+    console.error("Risk Forecast Error:", error);
+    throw new Error("Failed to fetch holding risk forecast.");
+  }
+}

--- a/src/lib/types/riskForecast.ts
+++ b/src/lib/types/riskForecast.ts
@@ -1,7 +1,10 @@
 export type RiskForecast = {
   tickers: string[];
   weights: number[];
-  variance: number;
   volatility: number;
   beta: number;
+  tracking_error: number;
+  fund?: string;
+  ticker?: string;
+  fund_weight?: number;
 };


### PR DESCRIPTION
- took off variance
- added individual holding metrics 
- included portfolio weights instead of tracking error on the individual holdings (seemed like a more useful metric in that scenario) 

Let me know what you think about this, idk what would be most helpful. For the individual stocks, tracking error, because we are using the stock as 100% of its own portfolio, the numbers were coming back like 40% or huge numbers. I figured portfolio weight might be more useful, so I changed that 3rd card to portfolio weight for holdings. 