### PR TITLE
fix annualized metrics calculations

### DIFF
--- a/src/components/AllPortfoliosDataTable.tsx
+++ b/src/components/AllPortfoliosDataTable.tsx
@@ -57,23 +57,6 @@ const makeHeader = (label: string, description?: React.ReactNode) => {
     />
   );
 };
-const sortableHeader = (
-  label: string,
-  description: React.ReactNode | undefined,
-  column: any,
-) => (
-  <div className="flex items-center gap-1">
-    {makeHeader(label, description)}
-    <Button
-      variant="ghost"
-      size="icon"
-      className="h-6 w-6 p-0"
-      onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-    >
-      <ArrowUpDown className="h-4 w-4" />
-    </Button>
-  </div>
-);
 
 const tooltipColumns = [
   "Value",
@@ -88,7 +71,6 @@ const tooltipColumns = [
   "Information Ratio",
 ] as const;
 
-// false = Realized
 const headerTooltips = getHeaderTooltips(false, tooltipColumns);
 
 export const columns: ColumnDef<AllPortfoliosRecord>[] = [

--- a/src/lib/RealizedVsAnnualizedCalculations.ts
+++ b/src/lib/RealizedVsAnnualizedCalculations.ts
@@ -1,6 +1,7 @@
 type PeriodSummary = {
   start: string;
   end: string;
+  trading_days: number;
   volatility: number;
   sharpe_ratio?: number;
   alpha: number;
@@ -11,6 +12,7 @@ type PeriodSummary = {
 type BenchmarkSummary = {
   start: string;
   end: string;
+  trading_days: number;
   volatility: number;
   sharpe_ratio: number;
   dividend_yield: number;
@@ -21,59 +23,64 @@ export function calculateSummaryMetrics(
   summary?: PeriodSummary,
   benchmark?: BenchmarkSummary,
 ) {
-  const daysBetween = (start: string, end: string) =>
-    Math.max(1, (Date.parse(end) - Date.parse(start)) / 864e5);
+  // single wrapper: ensure `days` is provided and non-zero before calling
+  const withDaysCheck =
+    <T extends (v: number, d: number) => number>(fn: T) =>
+    (value: number, days?: number): number | undefined => {
+      if (!days || days === 0) return undefined;
+      return fn(value, days as number);
+    };
 
-  const annStd = (periodStd: number, days: number) =>
-    periodStd * Math.sqrt(252 / days);
+  const annSqRt = withDaysCheck(
+    (value: number, days: number) => value * Math.sqrt(252 / days),
+  );
 
-  const annReturn = (periodReturn: number, days: number) =>
-    periodReturn * (252 / days);
+  const ann = withDaysCheck(
+    (value: number, days: number) => value * (252 / days),
+  );
 
-  const toggle = (realized: number, annualizedValue: number) =>
-    annualized ? annualizedValue : realized;
+  const toggle = (
+    realized: number,
+    annualizedValue?: number,
+  ): number | undefined => (annualized ? annualizedValue : realized);
 
-  const days = summary ? daysBetween(summary.start, summary.end) : 1;
-  const benchDays = benchmark ? daysBetween(benchmark.start, benchmark.end) : 1;
+  const days = summary?.trading_days;
+  const benchDays = benchmark?.trading_days;
+  console.log("calculateSummaryMetrics days", days);
+  console.log("calculateSummaryMetrics benchDays", benchDays);
 
   const fundVol = summary
-    ? toggle(summary.volatility, annStd(summary.volatility, days))
+    ? toggle(summary.volatility, annSqRt(summary.volatility, days))
     : undefined;
 
   const fundSharpe =
     summary && summary.sharpe_ratio != null
-      ? toggle(
-          summary.sharpe_ratio,
-          summary.sharpe_ratio * Math.sqrt(252 / days),
-        )
+      ? toggle(summary.sharpe_ratio, annSqRt(summary.sharpe_ratio, days))
       : undefined;
 
   const fundAlpha = summary
-    ? toggle(summary.alpha, annReturn(summary.alpha, days))
+    ? toggle(summary.alpha, ann(summary.alpha, days))
     : undefined;
 
   const fundTE =
     summary && summary.tracking_error !== undefined
-      ? toggle(summary.tracking_error, annStd(summary.tracking_error, days))
+      ? toggle(summary.tracking_error, annSqRt(summary.tracking_error, days))
       : undefined;
 
   const fundIR =
     summary && summary.information_ratio != null
       ? toggle(
           summary.information_ratio,
-          summary.information_ratio * Math.sqrt(252 / days),
+          annSqRt(summary.information_ratio, days),
         )
       : undefined;
 
   const benchVol = benchmark
-    ? toggle(benchmark.volatility, annStd(benchmark.volatility, benchDays))
+    ? toggle(benchmark.volatility, annSqRt(benchmark.volatility, benchDays))
     : undefined;
 
   const benchSharpe = benchmark
-    ? toggle(
-        benchmark.sharpe_ratio,
-        benchmark.sharpe_ratio * Math.sqrt(252 / benchDays),
-      )
+    ? toggle(benchmark.sharpe_ratio, annSqRt(benchmark.sharpe_ratio, benchDays))
     : undefined;
 
   return {

--- a/src/lib/RealizedVsAnnualizedCalculations.ts
+++ b/src/lib/RealizedVsAnnualizedCalculations.ts
@@ -46,8 +46,6 @@ export function calculateSummaryMetrics(
 
   const days = summary?.trading_days;
   const benchDays = benchmark?.trading_days;
-  console.log("calculateSummaryMetrics days", days);
-  console.log("calculateSummaryMetrics benchDays", benchDays);
 
   const fundVol = summary
     ? toggle(summary.volatility, annSqRt(summary.volatility, days))

--- a/src/lib/types/allHoldings.ts
+++ b/src/lib/types/allHoldings.ts
@@ -23,5 +23,6 @@ export interface AllHoldingsSummaryResponse {
   fund: string;
   start: string;
   end: string;
+  trading_days: number;
   holdings: AllHoldingsRecord[];
 }

--- a/src/lib/types/allPortfolios.ts
+++ b/src/lib/types/allPortfolios.ts
@@ -20,5 +20,6 @@ export interface AllPortfoliosRecord {
 export interface AllPortfoliosSummaryResponse {
   start: string;
   end: string;
+  trading_days: number;
   portfolios: AllPortfoliosRecord[];
 }

--- a/src/lib/types/benchmark.ts
+++ b/src/lib/types/benchmark.ts
@@ -8,6 +8,7 @@ export interface BenchmarkRequest {
 export interface BenchmarkSummaryResponse {
   start: string;
   end: string;
+  trading_days: number;
   adjusted_close: number;
   total_return: number;
   sharpe_ratio: number;

--- a/src/lib/types/fund.ts
+++ b/src/lib/types/fund.ts
@@ -6,6 +6,7 @@ export interface FundRequest {
 export interface FundSummaryResponse {
   start: string; // ISO date string
   end: string; // ISO date string
+  trading_days: number;
   value: number;
   total_return: number;
   sharpe_ratio: number;

--- a/src/lib/types/holding.ts
+++ b/src/lib/types/holding.ts
@@ -10,6 +10,7 @@ export interface HoldingSummaryResponse {
   ticker: string;
   start: string;
   end: string;
+  trading_days: number;
   active: boolean;
   shares: number;
   price: number;

--- a/src/lib/types/portfolio.ts
+++ b/src/lib/types/portfolio.ts
@@ -8,6 +8,7 @@ export interface PortfolioSummaryResponse {
   fund: string;
   start: string;
   end: string;
+  trading_days: number;
   value: number;
   total_return: number;
   sharpe_ratio: number;


### PR DESCRIPTION
changed annualized calculations to use trading days difference instead of all days difference
- Trading days are passed through from api based on count of unique days pulled from table in given date range