### PR TITLE
Fix hardcode realized days

### DIFF
--- a/src/app/performance/[fund]/[holding]/page.tsx
+++ b/src/app/performance/[fund]/[holding]/page.tsx
@@ -156,6 +156,7 @@ export default function Page() {
               ticker={params.holding}
               holdingSummary={holdingSummary}
               benchmarkSummary={benchmarkSummary}
+              view_1yr={view === "1year"}
             />
           </Card>
           {/* Row 3 */}

--- a/src/app/performance/[fund]/page.tsx
+++ b/src/app/performance/[fund]/page.tsx
@@ -137,6 +137,7 @@ export default function Page() {
               portfolio={fund}
               portfolioSummary={portfolioSummary}
               benchmarkSummary={benchmarkSummary}
+              view_1yr={view === "1year"}
             />
           </Card>
           {/* Row 3 */}

--- a/src/app/performance/page.tsx
+++ b/src/app/performance/page.tsx
@@ -78,6 +78,7 @@ export default function Page() {
     }
   }, [start, end]);
 
+  console.log(view);
   return (
     <div className="lg:px-24 md:px-12 sm:px-6">
       <div className="space-y-4 p-4">
@@ -108,6 +109,7 @@ export default function Page() {
             <FundSummaryTable
               allFundsSummary={fundSummary}
               benchmarkSummary={benchmarkSummary}
+              view_1yr={view === "1year"}
             />
           </Card>
           {/* Row 3 */}

--- a/src/components/AllHoldingsDataTable.tsx
+++ b/src/components/AllHoldingsDataTable.tsx
@@ -157,9 +157,7 @@ export const columns: ColumnDef<AllHoldingsRecord>[] = [
         column,
       ),
     cell: ({ row }) => (
-      <div>
-        {formatPercent((row.getValue("alpha_contribution") as number) * 100)}
-      </div>
+      <div>{formatPercent(row.getValue("alpha_contribution"))}</div>
     ),
   },
   {

--- a/src/components/AllHoldingsDataTable.tsx
+++ b/src/components/AllHoldingsDataTable.tsx
@@ -78,6 +78,7 @@ const tooltipColumns = [
   "Total Return",
   "Volatility",
   "Alpha",
+  "Alpha Contribution",
   "Beta",
   "Dividends",
   "Per Share",
@@ -96,6 +97,7 @@ const headerTooltips: Record<string, React.ReactNode | undefined> = {
   Return: shared["Total Return"],
   Volatility: shared["Volatility"],
   Alpha: shared["Alpha"],
+  "Alpha Contribution": shared["Alpha Contribution"],
   Beta: shared["Beta"],
   Dividends: shared["Dividends"],
   "Per Share": shared["Per Share"],
@@ -144,6 +146,21 @@ export const columns: ColumnDef<AllHoldingsRecord>[] = [
     header: ({ column }) =>
       sortableHeader("Volatility", headerTooltips["Volatility"], column),
     cell: ({ row }) => <div>{formatPercent(row.getValue("volatility"))}</div>,
+  },
+
+  {
+    accessorKey: "alpha_contribution",
+    header: ({ column }) =>
+      sortableHeader(
+        "Alpha Contribution",
+        headerTooltips["Alpha Contribution"],
+        column,
+      ),
+    cell: ({ row }) => (
+      <div>
+        {formatPercent((row.getValue("alpha_contribution") as number) * 100)}
+      </div>
+    ),
   },
   {
     accessorKey: "alpha",

--- a/src/components/FundSummaryTable.tsx
+++ b/src/components/FundSummaryTable.tsx
@@ -21,9 +21,11 @@ import { calculateSummaryMetrics } from "@/lib/RealizedVsAnnualizedCalculations"
 export function FundSummaryTable({
   allFundsSummary,
   benchmarkSummary,
+  view_1yr,
 }: {
   allFundsSummary: FundSummaryResponse | undefined;
   benchmarkSummary: BenchmarkSummaryResponse | undefined;
+  view_1yr?: boolean;
 }) {
   const makeHeader = (label: string, description?: React.ReactNode) => {
     if (description === undefined) return <span>{label}</span>;
@@ -50,7 +52,12 @@ export function FundSummaryTable({
     fundIR,
     benchVol,
     benchSharpe,
-  } = calculateSummaryMetrics(annualized, allFundsSummary, benchmarkSummary);
+  } = calculateSummaryMetrics(
+    annualized,
+    allFundsSummary,
+    benchmarkSummary,
+    view_1yr,
+  );
   const columns = [
     "Value",
     "Total Return",

--- a/src/components/HoldingSummaryTable.tsx
+++ b/src/components/HoldingSummaryTable.tsx
@@ -22,10 +22,12 @@ export function HoldingSummaryTable({
   ticker,
   holdingSummary,
   benchmarkSummary,
+  view_1yr,
 }: {
   ticker: string;
   holdingSummary: HoldingSummaryResponse | undefined;
   benchmarkSummary: BenchmarkSummaryResponse | undefined;
+  view_1yr?: boolean;
 }) {
   const makeHeader = (label: string, description?: React.ReactNode) => {
     if (description === undefined) return <span>{label}</span>;
@@ -48,6 +50,7 @@ export function HoldingSummaryTable({
     annualized,
     holdingSummary,
     benchmarkSummary,
+    view_1yr,
   );
   const columns = [
     "Value",

--- a/src/components/PortfolioSummarytable.tsx
+++ b/src/components/PortfolioSummarytable.tsx
@@ -31,10 +31,12 @@ export function PortfolioSummaryTable({
   portfolio,
   portfolioSummary,
   benchmarkSummary,
+  view_1yr,
 }: {
   portfolio: string;
   portfolioSummary: PortfolioSummaryResponse | undefined;
   benchmarkSummary: BenchmarkSummaryResponse | undefined;
+  view_1yr?: boolean;
 }) {
   const makeHeader = (label: string, description?: React.ReactNode) => {
     if (description === undefined) return <span>{label}</span>;
@@ -76,7 +78,12 @@ export function PortfolioSummaryTable({
     fundIR,
     benchVol,
     benchSharpe,
-  } = calculateSummaryMetrics(annualized, portfolioSummary, benchmarkSummary);
+  } = calculateSummaryMetrics(
+    annualized,
+    portfolioSummary,
+    benchmarkSummary,
+    view_1yr,
+  );
 
   return (
     <Table>

--- a/src/lib/RealizedVsAnnualizedCalculations.ts
+++ b/src/lib/RealizedVsAnnualizedCalculations.ts
@@ -1,6 +1,7 @@
 type PeriodSummary = {
   start: string;
   end: string;
+  trading_days: number;
   volatility: number;
   sharpe_ratio?: number;
   alpha: number;
@@ -11,6 +12,7 @@ type PeriodSummary = {
 type BenchmarkSummary = {
   start: string;
   end: string;
+  trading_days: number;
   volatility: number;
   sharpe_ratio: number;
   dividend_yield: number;
@@ -20,65 +22,64 @@ export function calculateSummaryMetrics(
   annualized: boolean,
   summary?: PeriodSummary,
   benchmark?: BenchmarkSummary,
+  view_1yr = false,
 ) {
-  const daysBetween = (start: string, end: string) =>
-    Math.max(1, (Date.parse(end) - Date.parse(start)) / 864e5);
+  // single wrapper: ensure `days` is provided and non-zero before calling
+  const withDaysCheck =
+    <T extends (v: number, d: number) => number>(fn: T) =>
+    (value: number, days?: number): number | undefined => {
+      if (!days || days === 0) return undefined;
+      return fn(value, days as number);
+    };
 
-  // For 1-year periods, use actual days; otherwise use 252
-  const tradingDaysInYear = (days: number) =>
-    days >= 250 && days <= 254 ? days : 252;
+  const annSqRt = withDaysCheck((value: number, days: number) =>
+    view_1yr ? value : value * Math.sqrt(252 / days),
+  );
 
-  const annStd = (periodStd: number, days: number) =>
-    periodStd * Math.sqrt(tradingDaysInYear(days) / days);
+  const ann = withDaysCheck((value: number, days: number) =>
+    view_1yr ? value : value * (252 / days),
+  );
 
-  const annReturn = (periodReturn: number, days: number) =>
-    periodReturn * (tradingDaysInYear(days) / days);
+  const toggle = (
+    realized: number,
+    annualizedValue?: number,
+  ): number | undefined => (annualized ? annualizedValue : realized);
 
-  const toggle = (realized: number, annualizedValue: number) =>
-    annualized ? annualizedValue : realized;
-
-  const days = summary ? daysBetween(summary.start, summary.end) : 1;
-  const benchDays = benchmark ? daysBetween(benchmark.start, benchmark.end) : 1;
+  const days = summary?.trading_days;
+  const benchDays = benchmark?.trading_days;
 
   const fundVol = summary
-    ? toggle(summary.volatility, annStd(summary.volatility, days))
+    ? toggle(summary.volatility, annSqRt(summary.volatility, days))
     : undefined;
 
   const fundSharpe =
     summary && summary.sharpe_ratio != null
-      ? toggle(
-          summary.sharpe_ratio,
-          summary.sharpe_ratio * Math.sqrt(tradingDaysInYear(days) / days),
-        )
+      ? toggle(summary.sharpe_ratio, annSqRt(summary.sharpe_ratio, days))
       : undefined;
 
   const fundAlpha = summary
-    ? toggle(summary.alpha, annReturn(summary.alpha, days))
+    ? toggle(summary.alpha, ann(summary.alpha, days))
     : undefined;
 
   const fundTE =
     summary && summary.tracking_error !== undefined
-      ? toggle(summary.tracking_error, annStd(summary.tracking_error, days))
+      ? toggle(summary.tracking_error, annSqRt(summary.tracking_error, days))
       : undefined;
 
   const fundIR =
     summary && summary.information_ratio != null
       ? toggle(
           summary.information_ratio,
-          summary.information_ratio * Math.sqrt(tradingDaysInYear(days) / days),
+          annSqRt(summary.information_ratio, days),
         )
       : undefined;
 
   const benchVol = benchmark
-    ? toggle(benchmark.volatility, annStd(benchmark.volatility, benchDays))
+    ? toggle(benchmark.volatility, annSqRt(benchmark.volatility, benchDays))
     : undefined;
 
   const benchSharpe = benchmark
-    ? toggle(
-        benchmark.sharpe_ratio,
-        benchmark.sharpe_ratio *
-          Math.sqrt(tradingDaysInYear(benchDays) / benchDays),
-      )
+    ? toggle(benchmark.sharpe_ratio, annSqRt(benchmark.sharpe_ratio, benchDays))
     : undefined;
 
   return {

--- a/src/lib/RealizedVsAnnualizedCalculations.ts
+++ b/src/lib/RealizedVsAnnualizedCalculations.ts
@@ -24,11 +24,15 @@ export function calculateSummaryMetrics(
   const daysBetween = (start: string, end: string) =>
     Math.max(1, (Date.parse(end) - Date.parse(start)) / 864e5);
 
+  // For 1-year periods, use actual days; otherwise use 252
+  const tradingDaysInYear = (days: number) =>
+    days >= 250 && days <= 254 ? days : 252;
+
   const annStd = (periodStd: number, days: number) =>
-    periodStd * Math.sqrt(days / days);
+    periodStd * Math.sqrt(tradingDaysInYear(days) / days);
 
   const annReturn = (periodReturn: number, days: number) =>
-    periodReturn * (days / days);
+    periodReturn * (tradingDaysInYear(days) / days);
 
   const toggle = (realized: number, annualizedValue: number) =>
     annualized ? annualizedValue : realized;
@@ -44,7 +48,7 @@ export function calculateSummaryMetrics(
     summary && summary.sharpe_ratio != null
       ? toggle(
           summary.sharpe_ratio,
-          summary.sharpe_ratio * Math.sqrt(days / days),
+          summary.sharpe_ratio * Math.sqrt(tradingDaysInYear(days) / days),
         )
       : undefined;
 
@@ -61,7 +65,7 @@ export function calculateSummaryMetrics(
     summary && summary.information_ratio != null
       ? toggle(
           summary.information_ratio,
-          summary.information_ratio * Math.sqrt(days / days),
+          summary.information_ratio * Math.sqrt(tradingDaysInYear(days) / days),
         )
       : undefined;
 
@@ -72,7 +76,8 @@ export function calculateSummaryMetrics(
   const benchSharpe = benchmark
     ? toggle(
         benchmark.sharpe_ratio,
-        benchmark.sharpe_ratio * Math.sqrt(benchDays / benchDays),
+        benchmark.sharpe_ratio *
+          Math.sqrt(tradingDaysInYear(benchDays) / benchDays),
       )
     : undefined;
 

--- a/src/lib/RealizedVsAnnualizedCalculations.ts
+++ b/src/lib/RealizedVsAnnualizedCalculations.ts
@@ -25,10 +25,10 @@ export function calculateSummaryMetrics(
     Math.max(1, (Date.parse(end) - Date.parse(start)) / 864e5);
 
   const annStd = (periodStd: number, days: number) =>
-    periodStd * Math.sqrt(252 / days);
+    periodStd * Math.sqrt(days / days);
 
   const annReturn = (periodReturn: number, days: number) =>
-    periodReturn * (252 / days);
+    periodReturn * (days / days);
 
   const toggle = (realized: number, annualizedValue: number) =>
     annualized ? annualizedValue : realized;
@@ -44,7 +44,7 @@ export function calculateSummaryMetrics(
     summary && summary.sharpe_ratio != null
       ? toggle(
           summary.sharpe_ratio,
-          summary.sharpe_ratio * Math.sqrt(252 / days),
+          summary.sharpe_ratio * Math.sqrt(days / days),
         )
       : undefined;
 
@@ -61,7 +61,7 @@ export function calculateSummaryMetrics(
     summary && summary.information_ratio != null
       ? toggle(
           summary.information_ratio,
-          summary.information_ratio * Math.sqrt(252 / days),
+          summary.information_ratio * Math.sqrt(days / days),
         )
       : undefined;
 
@@ -72,7 +72,7 @@ export function calculateSummaryMetrics(
   const benchSharpe = benchmark
     ? toggle(
         benchmark.sharpe_ratio,
-        benchmark.sharpe_ratio * Math.sqrt(252 / benchDays),
+        benchmark.sharpe_ratio * Math.sqrt(benchDays / benchDays),
       )
     : undefined;
 

--- a/src/lib/RealizedVsAnnualizedCalculations.ts
+++ b/src/lib/RealizedVsAnnualizedCalculations.ts
@@ -1,7 +1,7 @@
 type PeriodSummary = {
   start: string;
   end: string;
-  trading_days: number;
+  trading_days?: number;
   volatility: number;
   sharpe_ratio?: number;
   alpha: number;
@@ -12,7 +12,7 @@ type PeriodSummary = {
 type BenchmarkSummary = {
   start: string;
   end: string;
-  trading_days: number;
+  trading_days?: number;
   volatility: number;
   sharpe_ratio: number;
   dividend_yield: number;

--- a/src/lib/tabletooltips.ts
+++ b/src/lib/tabletooltips.ts
@@ -25,6 +25,9 @@ export function getHeaderTooltips<T extends readonly string[]>(
     "Dividend Yield":
       "Dividend Yield = Dividends ÷ Ending Value over the selected period.",
 
+    "Alpha Contribution":
+      "Alpha Contribution = Holding Alpha × Mean Weight over all days held.",
+
     Alpha: annualized
       ? undefined //annualized
       : undefined,


### PR DESCRIPTION
changed the annualized toggle to not multiply by an annualized ratio only on the 1 yr view. instead it passes value as is. This prevents and values in the summary tables from changing when the annualized / realized toggle is switched in 1 year view