### PR TITLE
Fix hardcode realized days (#146)

### DIFF
--- a/src/app/performance/[fund]/[holding]/page.tsx
+++ b/src/app/performance/[fund]/[holding]/page.tsx
@@ -156,6 +156,7 @@ export default function Page() {
               ticker={params.holding}
               holdingSummary={holdingSummary}
               benchmarkSummary={benchmarkSummary}
+              view_1yr={view === "1year"}
             />
           </Card>
           {/* Row 3 */}

--- a/src/app/performance/[fund]/page.tsx
+++ b/src/app/performance/[fund]/page.tsx
@@ -137,6 +137,7 @@ export default function Page() {
               portfolio={fund}
               portfolioSummary={portfolioSummary}
               benchmarkSummary={benchmarkSummary}
+              view_1yr={view === "1year"}
             />
           </Card>
           {/* Row 3 */}

--- a/src/app/performance/page.tsx
+++ b/src/app/performance/page.tsx
@@ -78,6 +78,7 @@ export default function Page() {
     }
   }, [start, end]);
 
+  console.log(view);
   return (
     <div className="lg:px-24 md:px-12 sm:px-6">
       <div className="space-y-4 p-4">
@@ -108,6 +109,7 @@ export default function Page() {
             <FundSummaryTable
               allFundsSummary={fundSummary}
               benchmarkSummary={benchmarkSummary}
+              view_1yr={view === "1year"}
             />
           </Card>
           {/* Row 3 */}

--- a/src/components/AllHoldingsDataTable.tsx
+++ b/src/components/AllHoldingsDataTable.tsx
@@ -78,6 +78,7 @@ const tooltipColumns = [
   "Total Return",
   "Volatility",
   "Alpha",
+  "Alpha Contribution",
   "Beta",
   "Dividends",
   "Per Share",
@@ -96,6 +97,7 @@ const headerTooltips: Record<string, React.ReactNode | undefined> = {
   Return: shared["Total Return"],
   Volatility: shared["Volatility"],
   Alpha: shared["Alpha"],
+  "Alpha Contribution": shared["Alpha Contribution"],
   Beta: shared["Beta"],
   Dividends: shared["Dividends"],
   "Per Share": shared["Per Share"],
@@ -144,6 +146,19 @@ export const columns: ColumnDef<AllHoldingsRecord>[] = [
     header: ({ column }) =>
       sortableHeader("Volatility", headerTooltips["Volatility"], column),
     cell: ({ row }) => <div>{formatPercent(row.getValue("volatility"))}</div>,
+  },
+
+  {
+    accessorKey: "alpha_contribution",
+    header: ({ column }) =>
+      sortableHeader(
+        "Alpha Contribution",
+        headerTooltips["Alpha Contribution"],
+        column,
+      ),
+    cell: ({ row }) => (
+      <div>{formatPercent(row.getValue("alpha_contribution"))}</div>
+    ),
   },
   {
     accessorKey: "alpha",

--- a/src/components/FundSummaryTable.tsx
+++ b/src/components/FundSummaryTable.tsx
@@ -21,9 +21,11 @@ import { calculateSummaryMetrics } from "@/lib/RealizedVsAnnualizedCalculations"
 export function FundSummaryTable({
   allFundsSummary,
   benchmarkSummary,
+  view_1yr,
 }: {
   allFundsSummary: FundSummaryResponse | undefined;
   benchmarkSummary: BenchmarkSummaryResponse | undefined;
+  view_1yr?: boolean;
 }) {
   const makeHeader = (label: string, description?: React.ReactNode) => {
     if (description === undefined) return <span>{label}</span>;
@@ -50,7 +52,12 @@ export function FundSummaryTable({
     fundIR,
     benchVol,
     benchSharpe,
-  } = calculateSummaryMetrics(annualized, allFundsSummary, benchmarkSummary);
+  } = calculateSummaryMetrics(
+    annualized,
+    allFundsSummary,
+    benchmarkSummary,
+    view_1yr,
+  );
   const columns = [
     "Value",
     "Total Return",

--- a/src/components/HoldingSummaryTable.tsx
+++ b/src/components/HoldingSummaryTable.tsx
@@ -22,10 +22,12 @@ export function HoldingSummaryTable({
   ticker,
   holdingSummary,
   benchmarkSummary,
+  view_1yr,
 }: {
   ticker: string;
   holdingSummary: HoldingSummaryResponse | undefined;
   benchmarkSummary: BenchmarkSummaryResponse | undefined;
+  view_1yr?: boolean;
 }) {
   const makeHeader = (label: string, description?: React.ReactNode) => {
     if (description === undefined) return <span>{label}</span>;
@@ -48,6 +50,7 @@ export function HoldingSummaryTable({
     annualized,
     holdingSummary,
     benchmarkSummary,
+    view_1yr,
   );
   const columns = [
     "Value",

--- a/src/components/PortfolioSummarytable.tsx
+++ b/src/components/PortfolioSummarytable.tsx
@@ -31,10 +31,12 @@ export function PortfolioSummaryTable({
   portfolio,
   portfolioSummary,
   benchmarkSummary,
+  view_1yr,
 }: {
   portfolio: string;
   portfolioSummary: PortfolioSummaryResponse | undefined;
   benchmarkSummary: BenchmarkSummaryResponse | undefined;
+  view_1yr?: boolean;
 }) {
   const makeHeader = (label: string, description?: React.ReactNode) => {
     if (description === undefined) return <span>{label}</span>;
@@ -76,7 +78,12 @@ export function PortfolioSummaryTable({
     fundIR,
     benchVol,
     benchSharpe,
-  } = calculateSummaryMetrics(annualized, portfolioSummary, benchmarkSummary);
+  } = calculateSummaryMetrics(
+    annualized,
+    portfolioSummary,
+    benchmarkSummary,
+    view_1yr,
+  );
 
   return (
     <Table>

--- a/src/lib/RealizedVsAnnualizedCalculations.ts
+++ b/src/lib/RealizedVsAnnualizedCalculations.ts
@@ -1,7 +1,7 @@
 type PeriodSummary = {
   start: string;
   end: string;
-  trading_days: number;
+  trading_days?: number;
   volatility: number;
   sharpe_ratio?: number;
   alpha: number;
@@ -12,7 +12,7 @@ type PeriodSummary = {
 type BenchmarkSummary = {
   start: string;
   end: string;
-  trading_days: number;
+  trading_days?: number;
   volatility: number;
   sharpe_ratio: number;
   dividend_yield: number;
@@ -22,6 +22,7 @@ export function calculateSummaryMetrics(
   annualized: boolean,
   summary?: PeriodSummary,
   benchmark?: BenchmarkSummary,
+  view_1yr = false,
 ) {
   // single wrapper: ensure `days` is provided and non-zero before calling
   const withDaysCheck =
@@ -31,12 +32,12 @@ export function calculateSummaryMetrics(
       return fn(value, days as number);
     };
 
-  const annSqRt = withDaysCheck(
-    (value: number, days: number) => value * Math.sqrt(252 / days),
+  const annSqRt = withDaysCheck((value: number, days: number) =>
+    view_1yr ? value : value * Math.sqrt(252 / days),
   );
 
-  const ann = withDaysCheck(
-    (value: number, days: number) => value * (252 / days),
+  const ann = withDaysCheck((value: number, days: number) =>
+    view_1yr ? value : value * (252 / days),
   );
 
   const toggle = (

--- a/src/lib/tabletooltips.ts
+++ b/src/lib/tabletooltips.ts
@@ -25,6 +25,9 @@ export function getHeaderTooltips<T extends readonly string[]>(
     "Dividend Yield":
       "Dividend Yield = Dividends ÷ Ending Value over the selected period.",
 
+    "Alpha Contribution":
+      "Alpha Contribution = Holding Alpha × Mean Weight over all days held.",
+
     Alpha: annualized
       ? undefined //annualized
       : undefined,


### PR DESCRIPTION
* display alpha contribution

* tooltip formula

* update data table

* fix: use actual days instead of hardcoded 252 for annualization (fixes #143)

* fix: only use actual days for 1-year periods, keep 252 for other periods

* change annualized vs realized for 1 year stats all_fund page

* match annualize and realize for 1yr view, for [fund] and [holding]

* type error fix